### PR TITLE
Added optional field SchemeTransactionId

### DIFF
--- a/Shift4/Response/Charge.cs
+++ b/Shift4/Response/Charge.cs
@@ -101,6 +101,9 @@ namespace Shift4.Response
         [JsonProperty("cvvCheck")]
         public CvvCheck CvvCheck { get; set; }
 
+        [JsonProperty("schemeTransactionId")]
+        public string SchemeTransactionId { get; set; }
+
         [JsonProperty("threeDSecureInfo")]
         public ThreeDSecureInfo ThreeDSecureInfo { get; set; }
 


### PR DESCRIPTION
Team from shift4 introduced new field with Charge response called SchemeTransactionId.  
<img width="395" height="128" alt="image" src="https://github.com/user-attachments/assets/84bb51fc-ee5c-48df-88bf-1acf22c5f19f" />
